### PR TITLE
Global Properties now refresh on track()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,20 @@ Keen.prototype.initialize = function() {
 
   // if you have a read-key, then load the full keen library
   var lib = this.options.readKey ? 'keen' : 'keen-tracker';
-  this.load({ lib: lib }, this.ready);
+  var self = this;
+  this.load({ lib: lib }, function() {
+    var traits = self.analytics.user().traits();
+    var id = self.analytics.user().userId;
+    if (traits || id) {
+      var user = {};
+      if (traits) user.traits = traits;
+      if (id) user.userId = id;
+      self.client.setGlobalProperties(function() {
+        return clone({ user: user });
+      });
+    }
+    self.ready();
+  });
 };
 
 /**
@@ -131,16 +144,6 @@ Keen.prototype.identify = function(identify) {
  */
 
 Keen.prototype.track = function(track) {
-  var traits = this.analytics.user().traits();
-  var id = this.analytics.user().userId;
-  if (traits || id) {
-    var user = {};
-    if (traits) user.traits = traits;
-    if (id) user.userId = id;
-    this.client.setGlobalProperties(function() {
-      return clone({ user: user });
-    });
-  }
   var props = track.properties();
   this.addons(props, track);
   this.client.addEvent(track.event(), props);

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,6 +131,16 @@ Keen.prototype.identify = function(identify) {
  */
 
 Keen.prototype.track = function(track) {
+  var traits = this.analytics.user().traits();
+  var id = this.analytics.user().userId;
+  if (traits || id) {
+    var user = {};
+    if (traits) user.traits = traits;
+    if (id) user.userId = id;
+    this.client.setGlobalProperties(function() {
+      return clone({ user: user });
+    });
+  }
   var props = track.properties();
   this.addons(props, track);
   this.client.addEvent(track.event(), props);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -65,6 +65,22 @@ describe('Keen IO', function() {
           readKey: ''
         });
       });
+
+      it('should always refresh global properties with user traits if present', function() {
+        var id = 'Devon Higgins';
+        var traits = { trait: 'Pretty Neat', id: id };
+        analytics.user().userId = id;
+        analytics.user().traits(traits);
+
+        // Notice no identify() call is made here.
+        // This is to emulate a page reload which loses the global
+        // properties that identify() saves.
+
+        analytics.initialize();
+        analytics.page();
+        var global_user = keen.client.client.globalProperties().user;
+        analytics.deepEqual(global_user, { userId: id, traits: traits });
+      });
     });
   });
 
@@ -257,21 +273,6 @@ describe('Keen IO', function() {
             addons: []
           }
         });
-      });
-
-      it('should always refresh global properties with user traits if present', function() {
-        var id = 'Devon Higgins';
-        var traits = { trait: 'Pretty Neat', id: id };
-        analytics.user().userId = id;
-        analytics.user().traits(traits);
-
-        // Notice no identify() call is made here.
-        // This is to emulate a page reload which loses the global
-        // properties that identify() saves.
-
-        analytics.track('event');
-        var global_user = keen.client.client.globalProperties().user;
-        analytics.deepEqual(global_user, { userId: id, traits: traits });
       });
 
       describe('addons', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -259,6 +259,21 @@ describe('Keen IO', function() {
         });
       });
 
+      it('should always refresh global properties with user traits if present', function() {
+        var id = 'Devon Higgins';
+        var traits = { trait: 'Pretty Neat', id: id };
+        analytics.user().userId = id;
+        analytics.user().traits(traits);
+
+        // Notice no identify() call is made here.
+        // This is to emulate a page reload which loses the global
+        // properties that identify() saves.
+
+        analytics.track('event');
+        var global_user = keen.client.client.globalProperties().user;
+        analytics.deepEqual(global_user, { userId: id, traits: traits });
+      });
+
       describe('addons', function() {
         it('should add ipAddon if enabled', function() {
           keen.options.ipAddon = true;


### PR DESCRIPTION
Previously if a client were to call identify() to set some user state,
load a different page, and then call track(), the user state would be
lost as Keen does not persist the GlobalProperties across page loads.

Now, much of the identify() work is performed within track() if user
state is present.  This updates the GlobalProperties before sending the
event to Keen, saving the developer from having to call identify() before
every track() call, just in case.

References issue #3 on Github.
