### PR TITLE
Update keen tracking

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+1.0.5 / 2016-05-23
+==================
+
+  * Update keen-js to v3.1.0 (latest possible without breaking changes)
+  * Create a new `KeenSegment` namespace for analytics.js-installed SDK and return existing `Keen` object if overwritten
+
 1.0.4 / 2016-05-07
 ==================
 

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "analytics.js-integration-keen-io",
   "repo": "segment-integrations/analytics.js-integration-keen-io",
   "description": "The Keen Io analytics.js integration.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+'use strict';
 
 /**
  * Module dependencies.
@@ -10,11 +11,12 @@ var clone = require('clone');
  * Expose `Keen IO` integration.
  */
 
-var Keen = module.exports = integration('Keen IO')
+var KeenSegment = module.exports = integration('Keen IO')
   .global('Keen')
+  .global('KeenSegment')
   .option('ipAddon', false)
   .option('projectId', '')
-  .option('readKey', '')
+  .option('readKey', false)
   .option('referrerAddon', false)
   .option('trackAllPages', false)
   .option('trackCategorizedPages', true)
@@ -22,39 +24,29 @@ var Keen = module.exports = integration('Keen IO')
   .option('uaAddon', false)
   .option('urlAddon', false)
   .option('writeKey', '')
-  .tag('<script src="//d26b395fwzu5fz.cloudfront.net/3.0.7/{{ lib }}.min.js">');
+  .tag('<script src=\'//d26b395fwzu5fz.cloudfront.net/keen-tracking-0.1.1.min.js\'>');
 
 /**
  * Initialize.
  *
+ * https://github.com/keen/keen-tracking.js
  * https://keen.io/docs/
  *
  * @api public
  */
 
-Keen.prototype.initialize = function() {
-  /**
-   * Shim out the Keen client library.
-   *
-   * To update the library, grab the most up-to-date embed code from Keen's
-   * JS library readme (https://github.com/keen/keen-js) and remove any of the
-   * script loading/appending business. Next, update the script tag above with
-   * the new client library URL.
-   */
-  /* eslint-disable */
-  !(function(a,b){if(void 0===b[a]){b["_"+a]={},b[a]=function(c){b["_"+a].clients=b["_"+a].clients||{},b["_"+a].clients[c.projectId]=this,this._config=c},b[a].ready=function(c){b["_"+a].ready=b["_"+a].ready||[],b["_"+a].ready.push(c)};for(var c=["addEvent","setGlobalProperties","trackExternalLink","on"],d=0;d<c.length;d++){var e=c[d],f=function(a){return function(){return this["_"+a]=this["_"+a]||[],this["_"+a].push(arguments),this}};b[a].prototype[e]=f(e)}}})("Keen",window);
-  /* eslint-enable */
-
+KeenSegment.prototype.initialize = function() {
   var options = this.options;
-  this.client = new window.Keen({
-    projectId: options.projectId,
-    writeKey: options.writeKey,
-    readKey: options.readKey
-  });
+  var self = this;
 
-  // if you have a read-key, then load the full keen library
-  var lib = this.options.readKey ? 'keen' : 'keen-tracker';
-  this.load({ lib: lib }, this.ready);
+  this.load({ lib: 'keen' }, function() {
+    window.KeenSegment = window.Keen.noConflict();
+    self.client = new window.KeenSegment({
+      projectId: options.projectId,
+      writeKey: options.writeKey
+    });
+    self.ready();
+  });
 };
 
 /**
@@ -64,8 +56,8 @@ Keen.prototype.initialize = function() {
  * @return {boolean}
  */
 
-Keen.prototype.loaded = function() {
-  return !!(window.Keen && window.Keen.prototype.configure);
+KeenSegment.prototype.loaded = function() {
+  return !!(window.KeenSegment && window.KeenSegment.prototype.configure);
 };
 
 /**
@@ -75,7 +67,7 @@ Keen.prototype.loaded = function() {
  * @param {Page} page
  */
 
-Keen.prototype.page = function(page) {
+KeenSegment.prototype.page = function(page) {
   var category = page.category();
   var name = page.fullName();
   var opts = this.options;
@@ -110,7 +102,7 @@ Keen.prototype.page = function(page) {
  * @param {Identify} identify
  */
 
-Keen.prototype.identify = function(identify) {
+KeenSegment.prototype.identify = function(identify) {
   var traits = identify.traits();
   var id = identify.userId();
   var user = {};
@@ -118,7 +110,7 @@ Keen.prototype.identify = function(identify) {
   if (traits) user.traits = traits;
   var props = { user: user };
   this.addons(props, identify);
-  this.client.setGlobalProperties(function() {
+  this.client.extendEvents(function() {
     return clone(props);
   });
 };
@@ -130,10 +122,10 @@ Keen.prototype.identify = function(identify) {
  * @param {Track} track
  */
 
-Keen.prototype.track = function(track) {
+KeenSegment.prototype.track = function(track) {
   var props = track.properties();
   this.addons(props, track);
-  this.client.addEvent(track.event(), props);
+  this.client.recordEvent(track.event(), props);
 };
 
 /**
@@ -144,7 +136,7 @@ Keen.prototype.track = function(track) {
  * @param {Facade} msg
  */
 
-Keen.prototype.addons = function(obj, msg) {
+KeenSegment.prototype.addons = function(obj, msg) {
   var options = this.options;
   var addons = [];
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ var KeenSegment = module.exports = integration('Keen IO')
   .option('uaAddon', false)
   .option('urlAddon', false)
   .option('writeKey', '')
-  .tag('<script src=\'//d26b395fwzu5fz.cloudfront.net/keen-tracking-0.1.1.min.js\'>');
+  .tag('<script src="//d26b395fwzu5fz.cloudfront.net/3.1.0/{{ lib }}.min.js">');
 
 /**
  * Initialize.
@@ -36,16 +36,22 @@ var KeenSegment = module.exports = integration('Keen IO')
  */
 
 KeenSegment.prototype.initialize = function() {
+  var lib = this.options.readKey ? 'keen' : 'keen-tracker';
   var options = this.options;
+  var previousKeen = window.Keen || null;
   var self = this;
 
-  this.load({ lib: 'keen' }, function() {
-    window.KeenSegment = window.Keen.noConflict();
+  this.load({ lib: lib }, function() {
+    window.KeenSegment = window.Keen;
     self.client = new window.KeenSegment({
       projectId: options.projectId,
+      readKey: options.readKey,
       writeKey: options.writeKey
     });
     self.ready();
+    if (previousKeen) {
+      window.Keen = previousKeen;
+    }
   });
 };
 
@@ -110,7 +116,7 @@ KeenSegment.prototype.identify = function(identify) {
   if (traits) user.traits = traits;
   var props = { user: user };
   this.addons(props, identify);
-  this.client.extendEvents(function() {
+  this.client.setGlobalProperties(function() {
     return clone(props);
   });
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -53,7 +53,7 @@ describe('Keen IO', function() {
         analytics.assert(!window.KeenSegment);
         analytics.initialize();
         analytics.page();
-        analytics.ready(function(){
+        analytics.ready(function() {
           analytics.assert(window.KeenSegment);
         });
       });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -142,19 +142,19 @@ describe('Keen IO', function() {
 
       it('should pass an id', function() {
         analytics.identify('id');
-        var user = keen.client.extensions.events[0]().user;
+        var user = keen.client.config.globalProperties().user;
         analytics.deepEqual(user, { userId: 'id', traits: { id: 'id' } });
       });
 
       it('should pass a traits', function() {
         analytics.identify({ trait: true });
-        var user = keen.client.extensions.events[0]().user;
+        var user = keen.client.config.globalProperties().user;
         analytics.deepEqual(user, { traits: { trait: true } });
       });
 
       it('should pass an id and traits', function() {
         analytics.identify('id', { trait: true });
-        var user = keen.client.extensions.events[0]().user;
+        var user = keen.client.config.globalProperties().user;
         analytics.deepEqual(user, { userId: 'id', traits: { trait: true, id: 'id' } });
       });
 
@@ -162,7 +162,7 @@ describe('Keen IO', function() {
         it('should add ipAddon if enabled', function() {
           keen.options.ipAddon = true;
           analytics.identify('id');
-          var props = keen.client.extensions.events[0]();
+          var props = keen.client.config.globalProperties();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:ip_to_geo',
@@ -175,7 +175,7 @@ describe('Keen IO', function() {
         it('should add uaAddon if enabled', function() {
           keen.options.uaAddon = true;
           analytics.identify('id');
-          var props = keen.client.extensions.events[0]();
+          var props = keen.client.config.globalProperties();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:ua_parser',
@@ -188,7 +188,7 @@ describe('Keen IO', function() {
         it('should add urlAddon if enabled', function() {
           keen.options.urlAddon = true;
           analytics.identify('id');
-          var props = keen.client.extensions.events[0]();
+          var props = keen.client.config.globalProperties();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:url_parser',
@@ -201,7 +201,7 @@ describe('Keen IO', function() {
         it('should add referrerAddon if enabled', function() {
           keen.options.referrerAddon = true;
           analytics.identify('id');
-          var props = keen.client.extensions.events[0]();
+          var props = keen.client.config.globalProperties();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:referrer_parser',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,10 @@
+'use strict';
 
 var Analytics = require('analytics.js-core').constructor;
 var integration = require('analytics.js-integration');
 var sandbox = require('clear-env');
 var tester = require('analytics.js-integration-tester');
-var Keen = require('../lib/');
+var KeenLib = require('../lib/');
 
 describe('Keen IO', function() {
   var analytics;
@@ -12,12 +13,11 @@ describe('Keen IO', function() {
     projectId: '53e40374e861700e79000002',
     writeKey: 'f474c11bcf5813fabc933d0a1f80ff2e1ac9ff1c9338dcf2707bbb8cf68971ae524b4cac8db5da549aa3383d499ed4a809e2b6294d1d093818d699495a4171dab3e6ad86e2c31d06627f27aadb8433f43c8f27f3e0354e6ea4c12f9da57ca9d8420b18c5e4f719286a0fae08914d9c44'
   };
-  var readKey = 'e5cdee9b7395b315bd8cc635f3b04fc07561d4e42889fe1b6ac719a9a4b45732c746666d83ce8644c8b0f06b867166654f900b67b250adbc225befac4b3a2562729c2ebebfbf19b1d13f631c2ed0c9f8de0be7897eded88102abe4366c7906011dd480631ed9ba60cdef84f908abc852';
 
   beforeEach(function() {
     analytics = new Analytics();
-    keen = new Keen(options);
-    analytics.use(Keen);
+    keen = new KeenLib(options);
+    analytics.use(KeenLib);
     analytics.use(tester);
     analytics.add(keen);
   });
@@ -30,11 +30,11 @@ describe('Keen IO', function() {
   });
 
   it('should have the right settings', function() {
-    analytics.compare(Keen, integration('Keen IO')
-      .global('Keen')
+    analytics.compare(KeenLib, integration('Keen IO')
+      .global('KeenSegment')
       .option('ipAddon', false)
       .option('projectId', '')
-      .option('readKey', '')
+      .option('readKey', false)
       .option('referrerAddon', false)
       .option('trackAllPages', false)
       .option('trackNamedPages', true)
@@ -49,42 +49,22 @@ describe('Keen IO', function() {
     });
 
     describe('#initialize', function() {
-      it('should create window.Keen', function() {
-        analytics.assert(!window.Keen);
+      it('should create window.KeenSegment', function() {
+        analytics.assert(!window.KeenSegment);
         analytics.initialize();
         analytics.page();
-        analytics.assert(window.Keen);
-      });
-
-      it('should configure Keen', function() {
-        analytics.initialize();
-        analytics.page();
-        analytics.deepEqual(keen.client._config, {
-          projectId: options.projectId,
-          writeKey: options.writeKey,
-          readKey: ''
+        analytics.ready(function(){
+          analytics.assert(window.KeenSegment);
         });
       });
-    });
-  });
 
-  describe('loading', function() {
-    beforeEach(function() {
-      analytics.spy(keen, 'load');
-    });
-
-    it('should load slim version by default', function(done) {
-      analytics.load(keen, function() {
-        analytics.assert(!window.Keen.Visualization);
-        done();
-      });
-    });
-
-    it('should load full version if you have a `readKey`', function(done) {
-      keen.options.readKey = readKey;
-      analytics.load(keen, function() {
-        analytics.assert(window.Keen.Visualization);
-        done();
+      it('should configure KeenSegment', function() {
+        analytics.initialize();
+        analytics.page();
+        analytics.ready(function() {
+          analytics.equal(keen.client.projectId(), options.projectId);
+          analytics.equal(keen.client.writeKey(), options.writeKey);
+        });
       });
     });
   });
@@ -98,33 +78,33 @@ describe('Keen IO', function() {
 
     describe('#page', function() {
       beforeEach(function() {
-        analytics.stub(keen.client, 'addEvent');
+        analytics.stub(keen.client, 'recordEvent');
       });
 
       it('should not track anonymous pages by default', function() {
         analytics.page();
-        analytics.didNotCall(keen.client.addEvent);
+        analytics.didNotCall(keen.client.recordEvent);
       });
 
       it('should track anonymous pages when the option is on', function() {
         keen.options.trackAllPages = true;
         analytics.page();
-        analytics.called(keen.client.addEvent, 'Loaded a Page');
+        analytics.called(keen.client.recordEvent, 'Loaded a Page');
       });
 
       it('should track named pages by default', function() {
         analytics.page('Name');
-        analytics.called(keen.client.addEvent, 'Viewed Name Page');
+        analytics.called(keen.client.recordEvent, 'Viewed Name Page');
       });
 
       it('should track named pages with categories', function() {
         analytics.page('Category', 'Name');
-        analytics.called(keen.client.addEvent, 'Viewed Category Name Page');
+        analytics.called(keen.client.recordEvent, 'Viewed Category Name Page');
       });
 
       it('should track categorized pages by default', function() {
         analytics.page('Category', 'Name');
-        analytics.called(keen.client.addEvent, 'Viewed Category Page');
+        analytics.called(keen.client.recordEvent, 'Viewed Category Page');
       });
 
       it('should not track a named or categorized page when the option is off', function() {
@@ -132,13 +112,13 @@ describe('Keen IO', function() {
         keen.options.trackCategorizedPages = false;
         analytics.page('Name');
         analytics.page('Category', 'Name');
-        analytics.didNotCall(keen.client.addEvent);
+        analytics.didNotCall(keen.client.recordEvent);
       });
 
-      it('should pass properties to .addEvent', function() {
+      it('should pass properties to .recordEvent', function() {
         var time = new Date();
         analytics.page('category', 'name', { prop: true }, { timestamp: time });
-        analytics.called(keen.client.addEvent, 'Viewed category name Page', {
+        analytics.called(keen.client.recordEvent, 'Viewed category name Page', {
           prop: true,
           path: location.pathname,
           referrer: '',
@@ -157,24 +137,24 @@ describe('Keen IO', function() {
 
     describe('#identify', function() {
       beforeEach(function() {
-        analytics.stub(keen.client, 'addEvent');
+        analytics.stub(keen.client, 'recordEvent');
       });
 
       it('should pass an id', function() {
         analytics.identify('id');
-        var user = keen.client.client.globalProperties().user;
+        var user = keen.client.extensions.events[0]().user;
         analytics.deepEqual(user, { userId: 'id', traits: { id: 'id' } });
       });
 
       it('should pass a traits', function() {
         analytics.identify({ trait: true });
-        var user = keen.client.client.globalProperties().user;
+        var user = keen.client.extensions.events[0]().user;
         analytics.deepEqual(user, { traits: { trait: true } });
       });
 
       it('should pass an id and traits', function() {
         analytics.identify('id', { trait: true });
-        var user = keen.client.client.globalProperties().user;
+        var user = keen.client.extensions.events[0]().user;
         analytics.deepEqual(user, { userId: 'id', traits: { trait: true, id: 'id' } });
       });
 
@@ -182,7 +162,7 @@ describe('Keen IO', function() {
         it('should add ipAddon if enabled', function() {
           keen.options.ipAddon = true;
           analytics.identify('id');
-          var props = keen.client.client.globalProperties();
+          var props = keen.client.extensions.events[0]();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:ip_to_geo',
@@ -195,7 +175,7 @@ describe('Keen IO', function() {
         it('should add uaAddon if enabled', function() {
           keen.options.uaAddon = true;
           analytics.identify('id');
-          var props = keen.client.client.globalProperties();
+          var props = keen.client.extensions.events[0]();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:ua_parser',
@@ -208,7 +188,7 @@ describe('Keen IO', function() {
         it('should add urlAddon if enabled', function() {
           keen.options.urlAddon = true;
           analytics.identify('id');
-          var props = keen.client.client.globalProperties();
+          var props = keen.client.extensions.events[0]();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:url_parser',
@@ -221,7 +201,7 @@ describe('Keen IO', function() {
         it('should add referrerAddon if enabled', function() {
           keen.options.referrerAddon = true;
           analytics.identify('id');
-          var props = keen.client.client.globalProperties();
+          var props = keen.client.extensions.events[0]();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:referrer_parser',
@@ -239,18 +219,18 @@ describe('Keen IO', function() {
 
     describe('#track', function() {
       beforeEach(function() {
-        analytics.stub(keen.client, 'addEvent');
+        analytics.stub(keen.client, 'recordEvent');
       });
 
       it('should pass an event', function() {
         analytics.track('event');
-        analytics.called(keen.client.addEvent, 'event');
+        analytics.called(keen.client.recordEvent, 'event');
       });
 
       it('should pass an event and properties', function() {
         var time = new Date();
         analytics.track('event', { property: true }, { timestamp: time });
-        analytics.called(keen.client.addEvent, 'event', {
+        analytics.called(keen.client.recordEvent, 'event', {
           property: true,
           keen: {
             timestamp: time,
@@ -263,7 +243,7 @@ describe('Keen IO', function() {
         it('should add ipAddon if enabled', function() {
           keen.options.ipAddon = true;
           analytics.track('event');
-          var props = keen.client.addEvent.args[0][1];
+          var props = keen.client.recordEvent.args[0][1];
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:ip_to_geo',
@@ -276,7 +256,7 @@ describe('Keen IO', function() {
         it('should add uaAddon if enabled', function() {
           keen.options.uaAddon = true;
           analytics.track('event');
-          var props = keen.client.addEvent.args[0][1];
+          var props = keen.client.recordEvent.args[0][1];
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:ua_parser',
@@ -289,7 +269,7 @@ describe('Keen IO', function() {
         it('should add urlAddon if enabled', function() {
           keen.options.urlAddon = true;
           analytics.track('event');
-          var props = keen.client.addEvent.args[0][1];
+          var props = keen.client.recordEvent.args[0][1];
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:url_parser',
@@ -302,7 +282,7 @@ describe('Keen IO', function() {
         it('should add referrerAddon if enabled', function() {
           keen.options.referrerAddon = true;
           analytics.track('event');
-          var props = keen.client.addEvent.args[0][1];
+          var props = keen.client.recordEvent.args[0][1];
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:referrer_parser',


### PR DESCRIPTION
## What does this PR do?

This PR updates the Keen IO integration to mitigate the potential for namespace collisions when using other versions of Keen SDKs.
- Update keen-js to v3.1.0 (latest possible without breaking changes)
- Create a new `KeenSegment` namespace for analytics.js-installed SDK and return existing `Keen` object if overwritten
