### PR TITLE
Prevent namespace collisions

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+1.0.5 / 2016-05-23
+==================
+
+  * Update keen-js to v3.1.0 (latest possible without breaking changes)
+  * Create a new `KeenSegment` namespace for analytics.js-installed SDK and return existing `Keen` object if overwritten
+
 1.0.4 / 2016-05-07
 ==================
 

--- a/component.json
+++ b/component.json
@@ -2,12 +2,12 @@
   "name": "analytics.js-integration-keen-io",
   "repo": "segment-integrations/analytics.js-integration-keen-io",
   "description": "The Keen Io analytics.js integration.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
     "segmentio/analytics.js-integration": "^1.1.0",
-    "component/clone": "0.1.0"
+    "component/clone": "0.1.1"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.12.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+'use strict';
 
 /**
  * Module dependencies.
@@ -11,7 +12,7 @@ var clone = require('clone');
  */
 
 var Keen = module.exports = integration('Keen IO')
-  .global('Keen')
+  .global('KeenSegment')
   .option('ipAddon', false)
   .option('projectId', '')
   .option('readKey', '')
@@ -22,7 +23,7 @@ var Keen = module.exports = integration('Keen IO')
   .option('uaAddon', false)
   .option('urlAddon', false)
   .option('writeKey', '')
-  .tag('<script src="//d26b395fwzu5fz.cloudfront.net/3.0.7/{{ lib }}.min.js">');
+  .tag('<script src="//d26b395fwzu5fz.cloudfront.net/3.1.0/{{ lib }}.min.js">');
 
 /**
  * Initialize.
@@ -33,28 +34,49 @@ var Keen = module.exports = integration('Keen IO')
  */
 
 Keen.prototype.initialize = function() {
-  /**
-   * Shim out the Keen client library.
-   *
-   * To update the library, grab the most up-to-date embed code from Keen's
-   * JS library readme (https://github.com/keen/keen-js) and remove any of the
-   * script loading/appending business. Next, update the script tag above with
-   * the new client library URL.
-   */
-  /* eslint-disable */
-  !(function(a,b){if(void 0===b[a]){b["_"+a]={},b[a]=function(c){b["_"+a].clients=b["_"+a].clients||{},b["_"+a].clients[c.projectId]=this,this._config=c},b[a].ready=function(c){b["_"+a].ready=b["_"+a].ready||[],b["_"+a].ready.push(c)};for(var c=["addEvent","setGlobalProperties","trackExternalLink","on"],d=0;d<c.length;d++){var e=c[d],f=function(a){return function(){return this["_"+a]=this["_"+a]||[],this["_"+a].push(arguments),this}};b[a].prototype[e]=f(e)}}})("Keen",window);
-  /* eslint-enable */
-
+  var lib = this.options.readKey ? 'keen' : 'keen-tracker';
   var options = this.options;
-  this.client = new window.Keen({
+  var previousKeen = window.Keen || null;
+  var self = this;
+
+  // Skip this step if keen-js@3.1.0 is already available
+  if (!window.Keen || window.Keen.version !== '3.1.0') {
+    // Force-undefine `Keen` (saved as `previousKeen`)
+    window.Keen = undefined;
+    /**
+      * Shim out the Keen client library.
+      *
+      * To update the library, grab the most up-to-date embed code from Keen's
+      * JS library readme (https://github.com/keen/keen-js) and remove any of the
+      * script loading/appending business. Next, update the script tag above with
+      * the new client library URL.
+    */
+    /* eslint-disable */
+    !(function(a,b){if(void 0===b[a]){b["_"+a]={},b[a]=function(c){b["_"+a].clients=b["_"+a].clients||{},b["_"+a].clients[c.projectId]=this,this._config=c},b[a].ready=function(c){b["_"+a].ready=b["_"+a].ready||[],b["_"+a].ready.push(c)};for(var c=["addEvent","setGlobalProperties","trackExternalLink","on"],d=0;d<c.length;d++){var e=c[d],f=function(a){return function(){return this["_"+a]=this["_"+a]||[],this["_"+a].push(arguments),this}};b[a].prototype[e]=f(e)}}})("Keen",window);
+    /* eslint-enable */
+    // keen-js@3.1.0 will be installed once `.load()` is called
+  }
+
+  // Define a safe namespace (stub)
+  window.KeenSegment = window.Keen;
+
+  // Define client (stub)
+  this.client = new window.KeenSegment({
     projectId: options.projectId,
-    writeKey: options.writeKey,
-    readKey: options.readKey
+    readKey: options.readKey,
+    writeKey: options.writeKey
   });
 
-  // if you have a read-key, then load the full keen library
-  var lib = this.options.readKey ? 'keen' : 'keen-tracker';
-  this.load({ lib: lib }, this.ready);
+  this.load({ lib: lib }, function() {
+    // Redefine safe namespace with full library
+    window.KeenSegment = window.Keen;
+    // Restore original `Keen`
+    if (previousKeen) {
+      window.Keen = previousKeen;
+      previousKeen = undefined;
+    }
+    self.ready();
+  });
 };
 
 /**
@@ -65,7 +87,7 @@ Keen.prototype.initialize = function() {
  */
 
 Keen.prototype.loaded = function() {
-  return !!(window.Keen && window.Keen.prototype.configure);
+  return !!(window.KeenSegment && window.KeenSegment.prototype.configure);
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,8 +16,6 @@ describe('Keen IO', function() {
   var readKey = 'e5cdee9b7395b315bd8cc635f3b04fc07561d4e42889fe1b6ac719a9a4b45732c746666d83ce8644c8b0f06b867166654f900b67b250adbc225befac4b3a2562729c2ebebfbf19b1d13f631c2ed0c9f8de0be7897eded88102abe4366c7906011dd480631ed9ba60cdef84f908abc852';
 
   beforeEach(function() {
-    // Test with previous version installed
-    window.Keen = { version: '3.4.1' };
     analytics = new Analytics();
     keen = new KeenLib(options);
     analytics.use(KeenLib);
@@ -92,9 +90,17 @@ describe('Keen IO', function() {
     });
 
     it('should preserve existing window.Keen', function(done) {
-      analytics.equal(window.Keen.version, '3.4.1');
+      window.Keen = { version: '3.4.1' };
       analytics.load(keen, function() {
         analytics.equal(window.Keen.version, '3.4.1');
+        done();
+      });
+    });
+
+    it('should expose window.Keen (v3.1.0) when no previous version is available', function(done) {
+      window.Keen = undefined;
+      analytics.load(keen, function() {
+        analytics.equal(window.Keen.version, '3.1.0');
         done();
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,10 @@
+'use strict';
 
 var Analytics = require('analytics.js-core').constructor;
 var integration = require('analytics.js-integration');
 var sandbox = require('clear-env');
 var tester = require('analytics.js-integration-tester');
-var Keen = require('../lib/');
+var KeenLib = require('../lib/');
 
 describe('Keen IO', function() {
   var analytics;
@@ -15,9 +16,11 @@ describe('Keen IO', function() {
   var readKey = 'e5cdee9b7395b315bd8cc635f3b04fc07561d4e42889fe1b6ac719a9a4b45732c746666d83ce8644c8b0f06b867166654f900b67b250adbc225befac4b3a2562729c2ebebfbf19b1d13f631c2ed0c9f8de0be7897eded88102abe4366c7906011dd480631ed9ba60cdef84f908abc852';
 
   beforeEach(function() {
+    // Test with previous version installed
+    window.Keen = { version: '3.4.1' };
     analytics = new Analytics();
-    keen = new Keen(options);
-    analytics.use(Keen);
+    keen = new KeenLib(options);
+    analytics.use(KeenLib);
     analytics.use(tester);
     analytics.add(keen);
   });
@@ -30,8 +33,8 @@ describe('Keen IO', function() {
   });
 
   it('should have the right settings', function() {
-    analytics.compare(Keen, integration('Keen IO')
-      .global('Keen')
+    analytics.compare(KeenLib, integration('Keen IO')
+      .global('KeenSegment')
       .option('ipAddon', false)
       .option('projectId', '')
       .option('readKey', '')
@@ -49,14 +52,14 @@ describe('Keen IO', function() {
     });
 
     describe('#initialize', function() {
-      it('should create window.Keen', function() {
-        analytics.assert(!window.Keen);
+      it('should create window.KeenSegment', function() {
+        analytics.assert(!window.KeenSegment);
         analytics.initialize();
         analytics.page();
-        analytics.assert(window.Keen);
+        analytics.assert(window.KeenSegment);
       });
 
-      it('should configure Keen', function() {
+      it('should configure KeenSegment', function() {
         analytics.initialize();
         analytics.page();
         analytics.deepEqual(keen.client._config, {
@@ -75,7 +78,7 @@ describe('Keen IO', function() {
 
     it('should load slim version by default', function(done) {
       analytics.load(keen, function() {
-        analytics.assert(!window.Keen.Visualization);
+        analytics.assert(!window.KeenSegment.Visualization);
         done();
       });
     });
@@ -83,7 +86,15 @@ describe('Keen IO', function() {
     it('should load full version if you have a `readKey`', function(done) {
       keen.options.readKey = readKey;
       analytics.load(keen, function() {
-        analytics.assert(window.Keen.Visualization);
+        analytics.assert(window.KeenSegment.Visualization);
+        done();
+      });
+    });
+
+    it('should preserve existing window.Keen', function(done) {
+      analytics.equal(window.Keen.version, '3.4.1');
+      analytics.load(keen, function() {
+        analytics.equal(window.Keen.version, '3.4.1');
         done();
       });
     });
@@ -162,19 +173,19 @@ describe('Keen IO', function() {
 
       it('should pass an id', function() {
         analytics.identify('id');
-        var user = keen.client.client.globalProperties().user;
+        var user = keen.client.config.globalProperties().user;
         analytics.deepEqual(user, { userId: 'id', traits: { id: 'id' } });
       });
 
       it('should pass a traits', function() {
         analytics.identify({ trait: true });
-        var user = keen.client.client.globalProperties().user;
+        var user = keen.client.config.globalProperties().user;
         analytics.deepEqual(user, { traits: { trait: true } });
       });
 
       it('should pass an id and traits', function() {
         analytics.identify('id', { trait: true });
-        var user = keen.client.client.globalProperties().user;
+        var user = keen.client.config.globalProperties().user;
         analytics.deepEqual(user, { userId: 'id', traits: { trait: true, id: 'id' } });
       });
 
@@ -182,7 +193,7 @@ describe('Keen IO', function() {
         it('should add ipAddon if enabled', function() {
           keen.options.ipAddon = true;
           analytics.identify('id');
-          var props = keen.client.client.globalProperties();
+          var props = keen.client.config.globalProperties();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:ip_to_geo',
@@ -195,7 +206,7 @@ describe('Keen IO', function() {
         it('should add uaAddon if enabled', function() {
           keen.options.uaAddon = true;
           analytics.identify('id');
-          var props = keen.client.client.globalProperties();
+          var props = keen.client.config.globalProperties();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:ua_parser',
@@ -208,7 +219,7 @@ describe('Keen IO', function() {
         it('should add urlAddon if enabled', function() {
           keen.options.urlAddon = true;
           analytics.identify('id');
-          var props = keen.client.client.globalProperties();
+          var props = keen.client.config.globalProperties();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:url_parser',
@@ -221,7 +232,7 @@ describe('Keen IO', function() {
         it('should add referrerAddon if enabled', function() {
           keen.options.referrerAddon = true;
           analytics.identify('id');
-          var props = keen.client.client.globalProperties();
+          var props = keen.client.config.globalProperties();
           var addon = props.keen.addons[0];
           analytics.deepEqual(addon, {
             name: 'keen:referrer_parser',


### PR DESCRIPTION
## What does this PR do?

This PR updates the Keen IO integration to mitigate the potential for namespace collisions when using other versions of Keen SDKs.
- Create a new `KeenSegment` namespace for analytics.js-installed SDK and restore existing `Keen` object if overwritten
- Update keen-js to v3.1.0 (latest possible without breaking changes)
- Version bump to v1.0.5
