### PR TITLE
Clone the object returned to setGlobalProperties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -140,7 +140,8 @@ Keen.prototype.identify = function(identify) {
   var props = { user: user };
   this.addons(props, identify);
   this.client.setGlobalProperties(function() {
-    return props;
+    // Clone the props so the Keen Client can't manipulate the ref
+    return JSON.parse(JSON.stringify(props));
   });
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@
  */
 
 var integration = require('@segment/analytics.js-integration');
+var clone = require('@ndhoule/clone');
 
 /**
  * Expose `Keen IO` integration.
@@ -141,7 +142,7 @@ Keen.prototype.identify = function(identify) {
   this.addons(props, identify);
   this.client.setGlobalProperties(function() {
     // Clone the props so the Keen Client can't manipulate the ref
-    return JSON.parse(JSON.stringify(props));
+    return clone(props);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-keen-io#readme",
   "dependencies": {
+    "@ndhoule/clone": "^1.0.0",
     "@segment/analytics.js-integration": "^2.1.0"
   },
   "devDependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -195,6 +195,13 @@ describe('Keen IO', function() {
         analytics.deepEqual(user, { userId: 'id', traits: { trait: true, id: 'id' } });
       });
 
+      it('should not have modified traits after addEvent', function() {
+        analytics.identify('id', { trait: true });
+        analytics.track('event', { other_trait: true });
+        
+        analytics.equal(typeof keen.client.config.globalProperties().user.traits.other_trait, 'undefined');
+      });
+
       describe('addons', function() {
         it('should add ipAddon if enabled', function() {
           keen.options.ipAddon = true;


### PR DESCRIPTION
The Keen client inadvertently manipulates the object returned by the `setGlobalProperties` function. That causes the global properties from `identify` to get bloated by unintended properties. Sending a cloned object instead of the original ref stops Keen from manipulating things.

@dustinlarimer 
